### PR TITLE
Update _footer.html.erb

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -74,7 +74,7 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-12 text-white text-left footer-copyright-text">
+      <div class="col-12 text-white text-center footer-copyright-text">
   <p><%= t("layout.footer.copyright_text",time_current_year: Time.current.year) %></p>
       </div>
     </div>


### PR DESCRIPTION
This updated footer html file moves the copyright text to the center

Fixes #

#### Describe the changes you have made in this PR -
This PR makes the footer content moves to the center
#Issue no 2899
### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
